### PR TITLE
Unify BC implementations

### DIFF
--- a/block/__init__.py
+++ b/block/__init__.py
@@ -15,8 +15,8 @@ from .block_mat import block_mat
 from .block_vec import block_vec
 from .block_compose import block_mul, block_add, block_sub, block_transpose
 from .block_transform import block_kronecker, block_simplify, block_collapse
-from .block_assemble import block_assemble, block_symmetric_assemble
 from .block_bc import block_bc
+from .block_assemble import block_assemble, block_symmetric_assemble
 from .block_util import issymmetric
 from .testing import check_expected
 

--- a/block/block_bc.py
+++ b/block/block_bc.py
@@ -1,17 +1,43 @@
 import dolfin
 from .block_mat import block_mat
 from .block_vec import block_vec
-from .block_util import wrap_in_list
+from .block_util import wrap_in_list, create_diagonal_matrix
 from .splitting import split_bcs
 import itertools
 import numpy
 
 class block_bc:
-    """This class applies Dirichlet BCs to a block matrix. It is not a block operator itself."""
+    """
+    This class applies Dirichlet BCs to a block matrix.  It is not a block
+    operator itself.
+
+    Creating bcs:
+
+    >>> bcs = block_bc([...], symmetric=...)
+
+    Basic inplace usage, with static BCs:
+
+    >>> rhs_bcs = bcs.apply(A)
+    >>> rhs_bcs.apply(b)
+
+    with the shortcut
+
+    >>> bcs.apply(A,b)
+
+    If boundary conditions are applied multiple times, it may be useful
+    to keep the original assembled mat/vec unchanged (for example, to
+    avoid having to re-assemble the RHS if the BC is time dependent but
+    the form itself isn't):
+
+    >>> Ainv = conjgrad(bcs(A))
+    >>> while True:
+    >>>     source.t = t
+    >>>     x = Ainv * bcs(b)
+    """
     def __init__(self, bcs, symmetric=False, signs=None, subspace_bcs=None):
         # Clean up self, and check arguments
         self.symmetric = symmetric
-        bcs = [wrap_in_list(bc) for bc in bcs]
+        bcs = [wrap_in_list(bc, dolfin.DirichletBC) for bc in bcs]
         if subspace_bcs is not None:
             subspace_bcs = split_bcs(subspace_bcs, None)
             combined_bcs = []
@@ -23,12 +49,30 @@ class block_bc:
         else:
             self.bcs = bcs
         self.signs = signs or [1]*len(self.bcs)
+        if not all(s in [-1,1] for s in self.signs):
+            raise ValueError('signs should be a list of length n containing only 1 or -1')
 
     @classmethod
-    def from_subspace(cls, bcs, *args, **kwargs):
+    def from_mixed(cls, bcs, *args, **kwargs):
         return cls([], *args, **kwargs, subspace_bcs=bcs)
 
-    def apply(self, A):
+    def __call__(self, other, A=None):
+        if isinstance(other, block_mat):
+            self._A = other # opportunistic, expecting a block_vec later
+            A = other.copy()
+            self.apply(A)
+            return A
+        elif isinstance(other, block_vec):
+            if A is None:
+                A = getattr(self, '_A', None) # opportunistic
+            if self.symmetric and A is None:
+                raise ValueError('A not available. Call with A first, or pass A=A.')
+            rhs = self.rhs(A)
+            return rhs(other)
+        else:
+            raise TypeError('BCs can only act on block_mat (A) or block_vec (b)')
+
+    def apply(self, A, b=None):
         """
         Apply BCs to a block_mat LHS, and return an object which modifies the
         corresponding block_vec RHS.  Typical use:
@@ -42,79 +86,115 @@ class block_bc:
         self._apply(A)
 
         # Create rhs_bc with a copy of A before any symmetric modifications
-        return block_rhs_bc(self.bcs, A_orig, symmetric=self.symmetric, signs=self.signs)
+        rhs = self.rhs(A_orig)
+        if b is not None:
+            rhs.apply(b)
+        return rhs
+
+    def rhs(self, A):
+        return block_rhs_bc(self.bcs, A, symmetric=self.symmetric, signs=self.signs)
 
     def _apply(self, A):
         if self.symmetric:
-            # dummy vec, required by dolfin api
+            # dummy vec, required by dolfin api -- we don't use this
+            # corrections directly since it may be time dependent
             b = A.create_vec(dim=0)
         for i,bcs in enumerate(self.bcs):
-            for bc in bcs:
+            if bcs:
                 for j in range(len(A)):
                     if i==j:
                         if numpy.isscalar(A[i,i]):
                             # Convert to a diagonal matrix, so that the individual rows can be modified
-                            from .block_assemble import _new_square_matrix
-                            A[i,i] = _new_square_matrix(bc, A[i,i])
+                            A[i,i] = create_diagonal_matrix(dolfin.FunctionSpace(bc.function_space()), A[i,i])
                         if self.symmetric:
-                            bc.zero_columns(A[i,i], b[i], self.signs[i])
+                            for bc in bcs:
+                                bc.zero_columns(A[i,i], b[i], self.signs[i])
                         else:
-                            bc.apply(A[i,i])
+                            if self.signs[i] != 1:
+                                A[i,i] *= 1/self.signs[i]
+                            for bc in bcs:
+                                bc.apply(A[i,i])
+                            if self.signs[i] != 1:
+                                A[i,i] *= self.signs[i]
                     else:
                         if numpy.isscalar(A[i,j]):
                             if A[i,j] != 0.0:
-                                dolfin.error("can't modify block (%d,%d) for BC, expected a GenericMatrix" % (i,j))
+                                dolfin.error("can't modify nonzero scalar off-diagonal block (%d,%d)" % (i,j))
                         else:
-                            bc.zero(A[i,j])
+                            for bc in bcs:
+                                bc.zero(A[i,j])
                         if self.symmetric:
                             if numpy.isscalar(A[j,i]):
                                 if A[j,i] != 0.0:
-                                    dolfin.error("can't modify block (%d,%d) for BC, expected a GenericMatrix" % (j,i))
+                                    dolfin.error("can't modify nonzero scalar off-diagonal block (%d,%d)" % (i,j))
                             else:
-                                bc.zero_columns(A[j,i], b[j])
+                                for bc in bcs:
+                                    bc.zero_columns(A[j,i], b[j])
 
 class block_rhs_bc:
+    """
+    This class applies Dirichlet BCs to a block block vector.  It can be used
+    as a block operator; but since it is nonlinear, it can only operate
+    directly on a block vector, and not combine with other operators.
+    """
     def __init__(self, bcs, A, symmetric, signs):
+        if symmetric:
+            assert A is not None
         self.bcs = bcs
         self.A = A
         self.symmetric = symmetric
         self.signs = signs
 
+    @property
+    def b_mod(self):
+        # First, collect a vector containing all non-zero BCs. These are required for
+        # symmetric modification.
+        x_mod = self.A.create_vec(dim=0)
+        x_mod.zero()
+        for i,bcs in enumerate(self.bcs):
+            for bc in bcs:
+                bc.apply(x_mod[i])
+
+        # The non-zeroes of x_mod are now exactly the x values. We can thus
+        # create the necessary modifications to b by just multiplying with the
+        # un-symmetricised original matrix. The bc values are overwritten
+        # later, hence only the non-bc rows of A matter.
+        return self.A * x_mod
+
     def apply(self, b):
-        """Apply Dirichlet boundary conditions, in a time loop for example,
-        when boundary conditions change. If the original vector was modified
-        for symmetry, it will remain so (since the BC dofs are not changed by
-        symmetry), but if any vectors have been individually reassembled then
-        it needs careful thought. It is probably better to just reassemble the
-        whole block_vec using block_assemble()."""
+        """Apply Dirichlet boundary conditions statically.  If BCs are mutable
+        (time dependent for example), it is more convenient to use the callable
+        form -- rhs_bc(b) -- to preserve the original contents of b for repeated
+        application without reassembly.
+        """
         if not isinstance(b, block_vec):
-            raise RuntimeError('not a block vector')
+            raise TypeError('not a block vector')
 
-        b.allocate(self.A, dim=0)
+        try:
+            b.allocate(self.A, dim=0, alternative_templates=[self.bcs])
+        except Exception:
+            raise ValueError('Failed to allocate block vector, call b.allocate(something) first')
 
+        # Correct for the matrix elements zeroed by symmetricization
         if self.symmetric:
-            # First, collect a vector containing all non-zero BCs. These are required for
-            # symmetric modification.
-            b_mod = self.A.create_vec(dim=0)
-            b_mod.zero()
-            for i,bcs in enumerate(self.bcs):
-                for bc in bcs:
-                    bc.apply(b_mod[i])
-                if self.signs[i] != 1:
-                    b_mod[i] *= self.signs[i]
-
-            # The non-zeroes of b_mod are now exactly the x values (scaled by
-            # sign, i.e. matrix diagonal). We can thus create the necessary
-            # modifications to b by just multiplying with the un-symmetricised
-            # original matrix.
-            b -= self.A * b_mod
+            b -= self.b_mod
 
         # Apply the actual BC dofs to b. (This must be done after the symmetric
         # correction above, since the correction might also change the BC dofs.)
+        # If the sign is negative, we negate twice to effectively apply -bc.
         for i,bcs in enumerate(self.bcs):
+            if self.signs[i] != 1 and bcs:
+                b[i] *= 1/self.signs[i]
             for bc in bcs:
                 bc.apply(b[i])
-            if self.signs[i] != 1:
+            if self.signs[i] != 1 and bcs:
                 b[i] *= self.signs[i]
 
         return self
+
+    def __call__(self, other):
+        if not isinstance(other, block_vec):
+            raise TypeError()
+        b = other.copy()
+        self.apply(b)
+        return b

--- a/block/block_util.py
+++ b/block/block_util.py
@@ -1,7 +1,3 @@
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
-
 def isequal(op1, op2, eps=1e-3):
     from . import block_vec
     v = op1.create_vec()
@@ -20,6 +16,15 @@ def issymmetric(op):
     opx = op*x
     err = (opx - op.T*x).norm('l2')/opx.norm('l2')
     return (err < 1e-6)
+
+def sign_of(op):
+    from numpy.random import random
+    if isscalar(op):
+        return -1 if op < 0 else 1
+    else:
+        x = op.create_vec(dim=1)
+        x.set_local(random(x.local_size()))
+        return -1 if x.inner(op*x) < 0 else 1
 
 def mult(op, x, transposed=False):
     if not transposed or isscalar(op):
@@ -117,3 +122,17 @@ def flatten(l):
                 yield sub
     else:
         yield l
+
+def create_diagonal_matrix(V, val=1.0):
+    from dolfin import TrialFunction, TestFunction
+    from dolfin import assemble, Constant, inner, dx
+    import numpy
+
+    u,v = TrialFunction(V),TestFunction(V)
+    Z = assemble(Constant(0)*inner(u,v)*dx)
+    if val != 0.0:
+        idx = numpy.arange(*Z.local_range(0), dtype=numpy.intc)
+        Z.ident(idx)
+        if val != 1.0:
+            Z *= val
+    return Z

--- a/block/block_vec.py
+++ b/block/block_vec.py
@@ -76,25 +76,8 @@ class block_vec(block_container):
                 ran -= MPI.sum(self[i].mpi_comm(), sum(ran))/MPI.sum(len(ran))
                 self[i][:] = ran
             else:
-                raise RuntimeError(
-                    'block %d in block_vec has no size -- use a proper vector or call allocate(A)' % i)
-
-    def apply_bc(self, bcs):
-        """Apply Dirichlet boundary conditions, in a time loop for example,
-        when boundary conditions change. If the original vector was modified
-        for symmetry, it will remain so (since the BC dofs are not changed by
-        symmetry), but if any vectors have been individually reassembled then
-        it needs careful thought. It is probably better to just reassemble the
-        whole block_vec using block_assemble()."""
-        from .block_util import create_vec_from, wrap_in_list
-        from dolfin import GenericVector
-        for i in range(len(self)):
-            if not isinstance(self[i], GenericVector):
-                vec = create_vec_from(bcs[i])
-                vec[:] = self[i]
-                self[i] = vec
-            for bc in wrap_in_list(bcs[i]):
-                bc.apply(self[i])
+                raise ValueError(
+                    f'block {i} in block_vec has no size -- use a proper vector or call allocate(A, dim=d)')
 
     #
     # Map operator on the block_vec to operators on the individual blocks.

--- a/block/block_vec.py
+++ b/block/block_vec.py
@@ -19,7 +19,7 @@ class block_vec(block_container):
         from dolfin import GenericVector
         return all(isinstance(block, GenericVector) for block in self)
 
-    def allocate(self, template, dim=None):
+    def allocate(self, template, dim=None, alternative_templates=[]):
         """Make sure all blocks are proper vectors. Any non-vector blocks are
         replaced with appropriately sized vectors (where the sizes are taken
         from the template, which should be a block_mat or a list of
@@ -35,8 +35,13 @@ class block_vec(block_container):
             val = self[i]
             try:
                 self[i] = create_vec_from(template[:,i] if dim==1 else template[i], dim)
-            except ValueError:
-                pass
+            except Exception:
+                for tmpl in alternative_templates:
+                    try:
+                        self[i] = create_vec_from(tmpl[:,i] if dim==1 else tmpl[i], dim)
+                        break
+                    except Exception:
+                        pass
             if not isinstance(self[i], GenericVector):
                 raise ValueError(
                     f"Can't allocate vector - no usable template for block {i}.\n"

--- a/block/dolfin_util.py
+++ b/block/dolfin_util.py
@@ -193,9 +193,11 @@ def rigid_body_modes(V, show_plot=False):
     basis.orthonormalize()
 
     if show_plot:
+        import matplotlib.pyplot as plt
         for mode in modes:
+            plt.figure()
             plot(Function(V,mode))
-        interactive()
+        plt.show()
 
     info("computed rigid body modes in %.2f s"%(timer.time()-T))
     return modes

--- a/block/splitting.py
+++ b/block/splitting.py
@@ -143,10 +143,14 @@ def _collapse_bc(bc):
 
 def split_bcs(bcs, m):
     # return a list of lists of DirichletBC for use with cbc.block
-    # we need the number of blocks m to ensure correct length of output list
+    # we need the number of blocks m to ensure correct length of output list;
+    # if m is None, the list will stop at the last active BC
+    bc_map = [_collapse_bc(bc) for bc in bcs]
+    if m is None:
+        m = max(i for i,_ in bc_map)+1
+
     collapsed_bcs = [[] for i in range(m)]
-    
-    for i, bc_i in map(_collapse_bc, bcs):
+    for i, bc_i in bc_map:
         collapsed_bcs[i].append(bc_i)
 
     return collapsed_bcs


### PR DESCRIPTION
There were three different implementations of application of Dirichlet BCs:
- block_vec
- block_bc
- block_assemble

The most complete, feature-wise, seemed to be in block_assemble.

This PR unifies the three by implementing missing features in block_bc and calling that from block_assemble. The (rudimentary) block_vec implementation is just removed.

The history of this duplication, if I remember correctly, is:

1. First, there was the block_bc implementation. It did not support symmetric BCs.
2. Then, we added a block_assemble method to fenics/dolfin to support symmetric BCs. This was mirrored in cbc.block, and this replaced the block_bc implementation.
3. block_bc was resurrected (probably because we figured out how to do the symmetric mod algebraically), but block_assemble was more efficient and also the only one to support MPI.
4. The block_assemble method was removed from fenics/dolfin because we were the only ones wanting it. Hence, no more efficiency or MPI. So in the end it had to have more or less the same implementation as block_bc, but in two separate places.

