### PR TITLE
Mark parts of code as supporting MPI or not

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     needs: tests
+    timeout-minutes: 5
 
     environment:
       name: pypi
@@ -45,6 +46,7 @@ jobs:
   deploy-to-web:
     runs-on: ubuntu-latest
     needs: tests
+    timeout-minutes: 5
 
     permissions:
       pages: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,6 +43,10 @@ jobs:
         run: |
           demo/regression-test.sh --coverage
 
+      - name: Run regression tests with MPI
+        run: |
+          demo/regression-test.sh --mpirun
+
       - name: Coverage report
         run: |
           coverage combine

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     permissions:
       contents: read

--- a/block/__init__.py
+++ b/block/__init__.py
@@ -11,6 +11,7 @@ In addition, methods are injected into dolfin.Matrix / dolfin.Vector as
 needed.
 """
 
+from .helpers import supports_mpi
 from .block_mat import block_mat
 from .block_vec import block_vec
 from .block_compose import block_mul, block_add, block_sub, block_transpose

--- a/block/algebraic/hazmath/precond.py
+++ b/block/algebraic/hazmath/precond.py
@@ -1,5 +1,5 @@
 from block.block_base import block_base
-from block import block_mat
+from block import block_mat, supports_mpi
 from builtins import str
 from petsc4py import PETSc
 from scipy.sparse import csr_matrix
@@ -195,9 +195,12 @@ class Precond(block_base):
     """
     Class of general preconditioners from HAZmath using SWIG
 
+    Note: Parallel execution (MPI) not supported.
     """
 
     def __init__(self, A, prectype=None, parameters=None, amg_parameters=None, precond=None):
+        supports_mpi(False, 'HAZMath does not work in parallel')
+
         # haznics.dCSRmat* type (assert?)
         self.A = A
         # python dictionary of parameters
@@ -314,6 +317,8 @@ class AMG(Precond):
     """
 
     def __init__(self, A, parameters=None):
+        supports_mpi(False, 'HAZMath does not work in parallel')
+
         # change data type for the matrix (to dCSRmat pointer)
         A_ptr = PETSc_to_dCSRmat(A)
 
@@ -345,6 +350,8 @@ class FAMG(Precond):
     """
 
     def __init__(self, A, M, parameters=None):
+        supports_mpi(False, 'HAZMath does not work in parallel')
+
         # change data type for the matrices (to dCSRmat pointer)
         A_ptr = PETSc_to_dCSRmat(A)
         M_ptr = PETSc_to_dCSRmat(M)
@@ -378,6 +385,8 @@ class RA(Precond):
     """
 
     def __init__(self, A, M, parameters=None):
+        supports_mpi(False, 'HAZMath does not work in parallel')
+
         # change data type for the matrices (to dCSRmat pointer)
         A_ptr = PETSc_to_dCSRmat(A)
         M_ptr = PETSc_to_dCSRmat(M)
@@ -422,6 +431,8 @@ class HXCurl(Precond):
     """
 
     def __init__(self, Acurl, V, parameters=None):
+        supports_mpi(False, 'HAZMath does not work in parallel')
+
         # get auxiliary operators
         mesh = V.mesh()
         Pc = Pcurl(mesh)
@@ -484,6 +495,8 @@ class HXDiv(Precond):
     """
 
     def __init__(self, Adiv, V, parameters=None):
+        supports_mpi(False, 'HAZMath does not work in parallel')
+
         # get auxiliary operators
         mesh = V.mesh()
         Pd = Pdiv(mesh)

--- a/block/algebraic/petsc/precond.py
+++ b/block/algebraic/petsc/precond.py
@@ -195,7 +195,7 @@ class SOR(precond):
         options.update(PETSc.Options().getAll())
         if parameters:
             options.update(parameters)
-        supports_mpi(not 'pc_sor_symmetric' in options, 'PetSC symmetric SOR not supported in parallel')
+        supports_mpi(not 'pc_sor_symmetric' in options, 'PETSc symmetric SOR not supported in parallel')
         precond.__init__(self, A, PETSc.PC.Type.SOR, options, pdes, nullspace)
 
 

--- a/block/algebraic/petsc/precond.py
+++ b/block/algebraic/petsc/precond.py
@@ -2,6 +2,7 @@ from __future__ import division
 
 from builtins import str
 from block.block_base import block_base
+from block.helpers import supports_mpi
 from block.object_pool import vec_pool
 from petsc4py import PETSc
 import dolfin as df
@@ -102,6 +103,7 @@ class ML(precond):
 
 class ILU(precond):
     def __init__(self, A, parameters=None, pdes=1, nullspace=None):
+        supports_mpi(False)
         precond.__init__(self, A, PETSc.PC.Type.ILU, parameters, pdes, nullspace)
 
 class Cholesky(precond):
@@ -193,6 +195,7 @@ class SOR(precond):
         options.update(PETSc.Options().getAll())
         if parameters:
             options.update(parameters)
+        supports_mpi(not 'pc_sor_symmetric' in options, 'PetSC symmetric SOR not supported in parallel')
         precond.__init__(self, A, PETSc.PC.Type.SOR, options, pdes, nullspace)
 
 

--- a/block/block_assemble.py
+++ b/block/block_assemble.py
@@ -16,7 +16,8 @@ def block_assemble(lhs, rhs=None, bcs=None,
             symmetric : Boundary conditions are applied so that symmetry of the system
                         is preserved. If only the left hand side of the system is given,
                         then a matrix represententing the rhs corrections is returned
-                        along with a symmetric matrix.
+                        along with a symmetric matrix. NOTE: Symmetric assembly not
+                        supported in parallel (MPI).
 
         symmetric_mod : Matrix describing symmetric corrections for assembly of the
                         of the rhs of a variational system.
@@ -34,11 +35,8 @@ def block_assemble(lhs, rhs=None, bcs=None,
     from numpy import ndarray
     has_rhs = True if isinstance(rhs, ndarray) else rhs != None
     has_lhs = True if isinstance(rhs, ndarray) else rhs != None
+    supports_mpi(not symmetric)
 
-    if symmetric:
-        from dolfin import MPI
-        if MPI.size(MPI.comm_world) > 1:
-            raise NotImplementedError(error_msg['mpi and symm'])
     if has_lhs and has_rhs:
         A, b = list(map(block_tensor,[lhs,rhs]))
         n, m = A.blocks.shape

--- a/block/block_bc.py
+++ b/block/block_bc.py
@@ -2,6 +2,7 @@ import dolfin
 from .block_mat import block_mat
 from .block_vec import block_vec
 from .block_util import wrap_in_list, create_diagonal_matrix
+from .helpers import supports_mpi
 from .splitting import split_bcs
 import itertools
 import numpy
@@ -51,6 +52,7 @@ class block_bc:
         self.signs = signs or [1]*len(self.bcs)
         if not all(s in [-1,1] for s in self.signs):
             raise ValueError('signs should be a list of length n containing only 1 or -1')
+        supports_mpi(not symmetric, 'Symmetric BCs not supported in parallel')
 
     @classmethod
     def from_mixed(cls, bcs, *args, **kwargs):

--- a/block/block_util.py
+++ b/block/block_util.py
@@ -24,6 +24,7 @@ def sign_of(op):
     else:
         x = op.create_vec(dim=1)
         x.set_local(random(x.local_size()))
+        x.apply('')
         return -1 if x.inner(op*x) < 0 else 1
 
 def mult(op, x, transposed=False):

--- a/block/block_vec.py
+++ b/block/block_vec.py
@@ -47,7 +47,9 @@ class block_vec(block_container):
                     f"Can't allocate vector - no usable template for block {i}.\n"
                     "Consider calling something like bb.allocate([V, Q]) to initialise the block_vec."
                 )
-            self[i][:] = val or 0.0
+            self[i].zero()
+            if val:
+                self[i] += val
 
     def norm(self, ntype='l2'):
         if ntype == 'linf':
@@ -72,6 +74,7 @@ class block_vec(block_container):
                 ran = numpy.random.random(self[i].local_size())
                 ran -= MPI.sum(self[i].mpi_comm(), sum(ran))/self[i].size()
                 self[i].set_local(ran)
+                self[i].apply('')
             elif hasattr(self[i], '__len__'):
                 ran = numpy.random.random(len(self[i]))
                 ran -= MPI.sum(self[i].mpi_comm(), sum(ran))/MPI.sum(len(ran))

--- a/block/helpers.py
+++ b/block/helpers.py
@@ -1,0 +1,14 @@
+class MpiNotSupported(Exception):
+    pass
+
+def supports_mpi(yesno, msg=None):
+    if not yesno:
+        from dolfin import MPI
+        if MPI.size(MPI.comm_world) > 1:
+            import os, sys
+            if os.environ.get('BLOCK_REGRESSION_MPIRUN'):
+                if MPI.comm_world.rank == 0:
+                    print(f'skip {sys.argv[0]}: {msg or "MPI not supported"}', file=sys.stderr)
+                sys.exit(0)
+            else:
+                raise MpiNotSupported(msg)

--- a/demo/mxpoisson-jump.py
+++ b/demo/mxpoisson-jump.py
@@ -27,8 +27,9 @@ from block.algebraic.petsc import *
 import os
 
 
-N = 48 
-mesh = UnitSquareMesh(N, N) 
+N = 48
+parameters['ghost_mode'] = 'shared_facet'
+mesh = UnitSquareMesh(N, N)
 # Define function spaces
 V = FunctionSpace(mesh, "BDM", 1)
 Q = FunctionSpace(mesh, "DG", 0)

--- a/demo/navierstokes.py
+++ b/demo/navierstokes.py
@@ -16,9 +16,7 @@ from block.iterative import *
 from block.algebraic.petsc import *
 
 set_log_level(15)
-if MPI.size(MPI.comm_world) > 1:
-    print ("Navier-Stokes demo does not work in parallel because of old-style XML mesh files")
-    exit()
+supports_mpi(False, "Navier-Stokes demo does not work in parallel because of old-style XML mesh files")
 
 # Load mesh and subdomains
 path = os.path.join(os.path.dirname(__file__), '')

--- a/demo/numpy_example.py
+++ b/demo/numpy_example.py
@@ -9,6 +9,8 @@ from block.algebraic.petsc import *
 
 import dolfin
 
+supports_mpi(False)
+
 class numpy_op(block_base):
     from block.object_pool import vec_pool
     import numpy

--- a/demo/numpy_test.py
+++ b/demo/numpy_test.py
@@ -8,9 +8,7 @@ from dolfin import *
 from block.dolfin_util import *
 import numpy
 
-if MPI.size(MPI.comm_world) > 1:
-    print ("numpy demo does not work in parallel")
-    exit()
+supports_mpi(False, "numpy demo does not work in parallel")
 
 # Function spaces, elements
 

--- a/demo/regression-test.sh
+++ b/demo/regression-test.sh
@@ -15,11 +15,13 @@
 
 set -e
 
+PARALLEL=-P4
 if [[ $1 == "--coverage" ]]; then
     export BLOCK_REGRESSION_COVERAGE=1
     shift
 elif [[ $1 == "--mpirun" ]]; then
     export BLOCK_REGRESSION_MPIRUN=1
+    PARALLEL=
     shift
 fi
 
@@ -47,6 +49,6 @@ export BLOCK_REGRESSION_ABORT=1
 
 demos=$(find "${0%/*}" -name \*.py)
 
-xargs -P4 -n1 "$0" <<<$demos
+xargs $PARALLEL -n1 "$0" <<<$demos
 
 ps -o etime,cputime $$

--- a/demo/regression-test.sh
+++ b/demo/regression-test.sh
@@ -36,7 +36,7 @@ if (( $# )); then
         cmd="python3"
     fi
     if [[ -n $BLOCK_REGRESSION_MPIRUN ]]; then
-        cmd="mpirun -np 3 $cmd"
+        cmd="mpirun -np 2 $cmd"
     fi
     echo $cmd $1
     # exit code 255 makes xargs abort immediately

--- a/demo/stokes.py
+++ b/demo/stokes.py
@@ -28,9 +28,7 @@ from block.algebraic.petsc import *
 
 import os
 
-#if MPI.size(None) > 1:
-#    print ("Stokes demo does not work in parallel because of old-style XML mesh files")
-#    exit()
+supports_mpi(False, "Stokes demo does not work in parallel because of old-style XML mesh files")
 
 # Load mesh and subdomains
 path = os.path.join(os.path.dirname(__file__), '')


### PR DESCRIPTION
Add markers (and descriptive exceptions) where MPI is not supported. This allows the regression tests to run in MPI as well.

There are also a few MPI fixes (mostly adding a call to `GenericVector.apply()` after modifying local vector data)