### PR TITLE
Fix docker build-publish

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -19,8 +19,7 @@ on:
         type: string
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: cbc-block
-
+  IMAGE_NAME: ${{ github.repository }}
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Result of pipeline on this branch is available at: https://github.com/blocknics/cbc.block/pkgs/container/cbc.block
I think we should merge this, trigger a manual build on `master` called which with tag with "latest", and then make the github package available once successful.